### PR TITLE
New scene bugfix

### DIFF
--- a/RecORDER.py
+++ b/RecORDER.py
@@ -428,21 +428,6 @@ def script_unload():
     isRecording = False
     defaultRecordingTitle = None
 
-class SettingsFile:
-    def __init__(self):
-        pass
-    
-    def open_settings_file():
-        pass
-    
-    def write_to_settings_file():
-        pass
-    
-    def close_settings_file():
-        pass
-
-            
-
 class Recording:
     """Class that allows better control over files for the needs of this script"""
 

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -172,6 +172,15 @@ def check_if_hooked_and_update_title():
     """
     global sourceUUID, gameTitle, defaultRecordingTitle
     
+    try:
+        if sourceUUID is None:
+            raise TypeError
+        
+    except TypeError:
+        print ("Source UUID is empty. Defaulting to \'Manual Recording\'")
+        gameTitle = defaultRecordingTitle
+        return 
+    
     calldata = get_hooked(sourceUUID)
     print("Checking if source is hooked to any window...")
     if calldata is not None:
@@ -243,6 +252,8 @@ def get_recording_source_uuid(configured_source):
         if scene_item:
             source = obs.obs_sceneitem_get_source(scene_item)
             source_uuid = obs.obs_source_get_uuid(source)
+        else:
+            source_uuid = None
 
     obs.obs_source_release(current_scene_as_source)
 
@@ -255,8 +266,10 @@ def refresh_source_uuid():
     if len(s_name) > 0:
         try:
             sourceUUID = get_recording_source_uuid(s_name)
-        except UnboundLocalError:
-            print("Source not found, please refresh and re-select")
+            if sourceUUID is None:
+                raise TypeError
+        except TypeError:
+            print("Source not selected, please refresh and re-select")
             sourceUUID = None
     else:
         sourceUUID = None

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -201,17 +201,6 @@ def get_hooked(uuid):
     ph = obs.obs_source_get_proc_handler(source)
     obs.proc_handler_call(ph, "get_hooked", cd)
     obs.obs_source_release(source)
-    # Possibly this return crashes the OBS if not found the source (see issue https://github.com/padiix/RecORDER/issues/3)
-    # TODO: Fix issue of null value on scene change 
-    # 
-    # Options to fix this issue:
-    # 1. ❎ (Not enough flexibility) Watch if not null value - if no, print out message in log
-    # 2. ✅ Keep values in outside file [like .json] and remember the source values. 
-    #        On load - check if file was created and load settings based on the settings file. 
-    #        If scene change detected - reset the source value
-    #        When no file found - load default values.
-    #        Create the .json file when user customizes the script - ex. on selection of a source.
-    #        (Optional) Add other parts of script settings into the file.
     return cd
 
 

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -23,9 +23,9 @@ sett = None
 
 # Values connected to recording
 currentRecording = None
-gameTitle = "Manual Recording"
+gameTitle = None
 isRecording = False
-
+defaultRecordingTitle = "Manual Recording"
 
 # SIGNAL-RELATED
 def start_rec_sh():
@@ -165,18 +165,19 @@ def replay_buffer_handler(event):
 
 
 def check_if_hooked_and_update_title():
-    global sourceUUID, gameTitle
     """Function checks if source selected by user is hooked to any window and takes the title of hooked window
 
     Raises:
         TypeError: Only triggers when sourceUUID is None and causes the title to reset to defaultRecordingName
     """
+    global sourceUUID, gameTitle, defaultRecordingTitle
+    
     calldata = get_hooked(sourceUUID)
     print("Checking if source is hooked to any window...")
     if calldata is not None:
         if not gh_isHooked(calldata):
             obs.calldata_destroy(calldata)
-            gameTitle = "Manual Recording"
+            gameTitle = defaultRecordingTitle
             print("Call data was empty, using default name for uncaptured windows...")
             return
         print("Hooked!")
@@ -397,7 +398,7 @@ def script_unload():
     # Fetching global variables
     global addTitleBool, recordingExtension, recordingExtensionMask, outputDir
     global sourceUUID, sett
-    global currentRecording, gameTitle, isRecording
+    global currentRecording, gameTitle, isRecording, defaultRecordingTitle
     # Clear Settings class
     addTitleBool = None
     recordingExtension = None
@@ -412,7 +413,7 @@ def script_unload():
     currentRecording = None
     gameTitle = None
     isRecording = False
-
+    defaultRecordingTitle = None
 
 class Recording:
     """Class that allows better control over files for the needs of this script"""

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -184,9 +184,9 @@ def get_hooked(uuid):
     # 
     # Options to fix this issue:
     # 1. ❎ (Not enough flexibility) Watch if not null value - if no, print out message in log
-    # 2. ❎ (Annoying to use for users with many scenes for everything) If scene change detected - reset the source value
-    # 3. ✅ Keep values in outside file [like .json] and remember the source values. 
+    # 2. ✅ Keep values in outside file [like .json] and remember the source values. 
     #        On load - check if file was created and load settings based on the settings file. 
+    #        If scene change detected - reset the source value
     #        When no file found - load default values.
     #        Create the .json file when user customizes the script - ex. on selection of a source.
     #        (Optional) Add other parts of script settings into the file.

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -165,6 +165,7 @@ def check_if_hooked_and_update_title():
         if not gh_isHooked(calldata):
             obs.calldata_destroy(calldata)
             gameTitle = "Manual Recording"
+            print("Call data was empty, using default name for uncaptured windows...")
             return
         print("Hooked!")
         gameTitle = gh_title(calldata)

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -428,6 +428,21 @@ def script_unload():
     isRecording = False
     defaultRecordingTitle = None
 
+class SettingsFile:
+    def __init__(self):
+        pass
+    
+    def open_settings_file():
+        pass
+    
+    def write_to_settings_file():
+        pass
+    
+    def close_settings_file():
+        pass
+
+            
+
 class Recording:
     """Class that allows better control over files for the needs of this script"""
 

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -179,6 +179,17 @@ def get_hooked(uuid):
     ph = obs.obs_source_get_proc_handler(source)
     obs.proc_handler_call(ph, "get_hooked", cd)
     obs.obs_source_release(source)
+    # Possibly this return crashes the OBS if not found the source (see issue https://github.com/padiix/RecORDER/issues/3)
+    # TODO: Fix issue of null value on scene change 
+    # 
+    # Options to fix this issue:
+    # 1. ❎ (Not enough flexibility) Watch if not null value - if no, print out message in log
+    # 2. ❎ (Annoying to use for users with many scenes for everything) If scene change detected - reset the source value
+    # 3. ✅ Keep values in outside file [like .json] and remember the source values. 
+    #        On load - check if file was created and load settings based on the settings file. 
+    #        When no file found - load default values.
+    #        Create the .json file when user customizes the script - ex. on selection of a source.
+    #        (Optional) Add other parts of script settings into the file.
     return cd
 
 

--- a/RecORDER.py
+++ b/RecORDER.py
@@ -29,6 +29,7 @@ isRecording = False
 
 # SIGNAL-RELATED
 def start_rec_sh():
+    """Signal handler function reacting to activation of recording."""
     output = obs.obs_frontend_get_recording_output()
     sh = obs.obs_output_get_signal_handler(output)
     obs.signal_handler_connect(sh, "activate", start_rec_cb)
@@ -36,6 +37,7 @@ def start_rec_sh():
 
 
 def start_rec_cb(calldata):
+    """Callback function reacting to the start_rec_sh signal handler function being triggered."""
     print("------------------------------")
     print("Recording has started...\n")
 
@@ -48,6 +50,7 @@ def start_rec_cb(calldata):
 
 
 def file_changed_sh():
+    """Signal handler function reacting to automatic file splitting."""
     output = obs.obs_frontend_get_recording_output()
     sh = obs.obs_output_get_signal_handler(output)
     obs.signal_handler_connect(sh, "file_changed", file_changed_cb)
@@ -55,6 +58,7 @@ def file_changed_sh():
 
 
 def file_changed_cb(calldata):
+    """Callback function reacting to the file_changed_sh signal handler function being triggered."""
     print("------------------------------")
     print("Refreshing sourceUUID...")
     refresh_source_uuid()
@@ -85,6 +89,7 @@ def file_changed_cb(calldata):
 
 
 def stop_rec_sh():
+    """Signal handler function reacting to stopping a recording."""
     output = obs.obs_frontend_get_recording_output()
     sh = obs.obs_output_get_signal_handler(output)
     obs.signal_handler_connect(sh, "stop", stop_rec_cb)
@@ -92,6 +97,7 @@ def stop_rec_sh():
 
 
 def stop_rec_cb(calldata):
+    """Callback function reacting to the stop_rec_sh signal handler function being triggered."""
     print("------------------------------")
     print("Refreshing sourceUUID...")
     refresh_source_uuid()
@@ -136,6 +142,7 @@ def stop_rec_cb(calldata):
 
 
 def replay_buffer_handler(event):
+    """Event function reacting to OBS Event of saving the replay buffer."""
     if event == obs.OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED:
         print("------------------------------")
         print("Saving the Replay Buffer...")
@@ -159,6 +166,11 @@ def replay_buffer_handler(event):
 
 def check_if_hooked_and_update_title():
     global sourceUUID, gameTitle
+    """Function checks if source selected by user is hooked to any window and takes the title of hooked window
+
+    Raises:
+        TypeError: Only triggers when sourceUUID is None and causes the title to reset to defaultRecordingName
+    """
     calldata = get_hooked(sourceUUID)
     print("Checking if source is hooked to any window...")
     if calldata is not None:
@@ -214,6 +226,11 @@ def remove_unusable_title_characters(title):
 
 
 def get_recording_source_uuid(configured_source):
+    """Checks if the source selected by user exists in the scene and returns found information.
+
+    Returns:
+        UUID: Source UUID or None
+    """
     global sourceUUID
     current_scene_as_source = obs.obs_frontend_get_current_scene()
 


### PR DESCRIPTION
* Added a watchdogs to look out for None value of the sourceUUID.
  * If sourceUUID is None for any reason, the script will not use anything, prompt the user to re-select the source in the Script Log and use defaultRecordingName variable value as a title.

> In the future, I'll try to make it work better, but for now it's a quickfix, so it won't crash the OBS for people that forget about re-selecting the source for new scenes.