### PR TITLE
Replay Buffer start event handler & method change for file moving

### DIFF
--- a/RecORDER.py
+++ b/RecORDER.py
@@ -2,6 +2,7 @@ import glob
 import obspython as obs  # type: ignore
 import re
 import os
+import time
 from pathlib import Path
 
 # Rewriting whole script using the Signals!
@@ -550,14 +551,6 @@ class Recording:
         oldPath = self.get_oldPath()
         newPath = self.get_newPath()
 
-        textFile = script_path() + "remember_move.txt"
-
-        with open(textFile, "w") as f:
-            f.write(newPath)
-
-        with open(textFile, "r") as f:
-            newPath = f.read()
-
-        os.remove(textFile)
+        time.sleep(0.01)
 
         os.renames(oldPath, newPath)


### PR DESCRIPTION
- Replay buffer acts like you would start recording now, so it will always take the freshest data
- File moving methods:
  - File moving was dealt with using the method of creation of dummy file with old data as to slow down the process, so it can be no longer used and moved (if file is in use, you would get PermissionError)
  - Right now the script utilizes the time.sleep() method instead, that will make the OBS process wait some amount of time (currently about 0.01 seconds; it's enough for my PC, so I cannot guarantee the same situation for all of you)